### PR TITLE
Change route base to /

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -287,7 +287,7 @@ class AdultProgramsView(FlaskView):
         return self.cbp.process_block_by_path(path)
 
 
-AdultProgramsView.register(app)
+AdultProgramsView.register(app, route_base="/")
 
 
 # Legacy cost per credit code


### PR DESCRIPTION
## Description

Changing the route from `/adultprograms/` to `/`, since there wasn’t a base index. We thought we were going to put more here, but we didn’t.

I’ll need to update confluence AND puppet cron paths before this gets merged.

Fixes #18

## Size and Type of change

- [x] Small Change - 1 person needs to review this
- [x] Puppet update needed

## How Has This Been Tested?

- Locally, I was able to get to `/` and can’t get to `/adultprograms/`. 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if needed) (I need to wait on this until its live)
- [x] I have thoroughly tested my change and am confident nothing will break