### PR TITLE
Reworked the process for the audit a bit

### DIFF
--- a/templates/sync_template.html
+++ b/templates/sync_template.html
@@ -68,7 +68,7 @@
                 </div>
                 <input type="button" class="btn" value="Sync all blocks" onclick="sync_all(document.getElementById('secToWait').value)">
                 <hr>
-                <p style="margin-top:10px">If you choose to sync just one block, it will not be published automatically.</p>
+                <p style="margin-top:10px">If you choose to sync just one block, it will not appear in the feeds until the "Sync all blocks" happens, which runs every morning.</p>
                 <div class="form-group row">
                     <label for="idToSync" class="col-6 col-form-label">ID or path of the block you want to sync right now:</label>
                     <div class="col-6">


### PR DESCRIPTION
## Description

This PR fixes some of the errors there were in the audit:
1) If the sync ever had an error, then it would consider everything new as “synced”. I changed this to only run AFTER we finish the sync.
2) If we ran the sync single block, it would consider every block as seen.

Both of those were major flaws in the design, as the program blocks are always out of date.

Fixes #20

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

- I was able to run the sync locally for both the sync by id and sync all. All I did was reorder things, which shouldn’t be an issue.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas