### PR TITLE
create new config var to skip values that exist in cms but not banner

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -150,7 +150,7 @@ class CascadeBlockProcessor:
         if find(block_asset, 'definitionPath', False) != 'Blocks/Program':
             return block_path + ' not in Blocks/Program'
 
-        if block_id in app.config['SKIP_CONCENTRATION_CODES']:
+        if block_id in app.config['SKIP_BLOCK_IDS']:
             return block_path + ' is currently being skipped.'
 
         # gather concentrations


### PR DESCRIPTION
## Description

Currently the "skip" list in the config only skips codes that exist in banner but not in cms. So I added a new variable in the config to skip codes that exist in cms but not in banner, although my guess is that we should probably just delete it from cms if it doesn't exist in banner but I don't think that is my responsibility 🤷‍♂️ , but let me know if it is.

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

- New feature

- Config update needed
* Add the variable `SKIP_BLOCK_IDS` to the config along with ids for athletic-training-program (2-MS-ATRG) and athletic-training-leadership-program (2-MA-ATLG)

## How Has This Been Tested?

I ran the code locally and verified that the current skip list only worked with data that exists in banner and doesn't in cms and then I tested it with the new var and it work as expected.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)